### PR TITLE
Fix "npm install" failing because of private registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -183,7 +183,7 @@
     },
     "node_modules/@hapi/accept": {
       "version": "5.0.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2faccept/-/accept-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
       "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -193,7 +193,7 @@
     },
     "node_modules/@hapi/ammo": {
       "version": "5.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fammo/-/ammo-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
       "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -202,7 +202,7 @@
     },
     "node_modules/@hapi/b64": {
       "version": "5.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fb64/-/b64-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
       "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -211,7 +211,7 @@
     },
     "node_modules/@hapi/boom": {
       "version": "9.1.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fboom/-/boom-9.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
       "integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -233,7 +233,7 @@
     },
     "node_modules/@hapi/bounce": {
       "version": "2.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fbounce/-/bounce-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
       "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -243,13 +243,13 @@
     },
     "node_modules/@hapi/bourne": {
       "version": "2.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fbourne/-/bourne-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
       "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/call": {
       "version": "8.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcall/-/call-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
       "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -259,7 +259,7 @@
     },
     "node_modules/@hapi/catbox": {
       "version": "11.1.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcatbox/-/catbox-11.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
       "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -271,7 +271,7 @@
     },
     "node_modules/@hapi/catbox-memory": {
       "version": "5.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcatbox-memory/-/catbox-memory-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
       "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -290,7 +290,7 @@
     },
     "node_modules/@hapi/content": {
       "version": "5.0.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcontent/-/content-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
       "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -299,7 +299,7 @@
     },
     "node_modules/@hapi/cryptiles": {
       "version": "5.1.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcryptiles/-/cryptiles-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
       "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -317,13 +317,13 @@
     },
     "node_modules/@hapi/file": {
       "version": "2.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2ffile/-/file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
       "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/hapi": {
       "version": "20.1.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fhapi/-/hapi-20.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.2.tgz",
       "integrity": "sha512-yLppH93as7vw+uaAMVcHEB13eBojuzGhcX948y/CGukNRAlnPV+c1EJGbYPLXVffpH8wCNsI7TrTaeifSFS6Vw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -352,7 +352,7 @@
     },
     "node_modules/@hapi/heavy": {
       "version": "7.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fheavy/-/heavy-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
       "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -363,7 +363,7 @@
     },
     "node_modules/@hapi/hoek": {
       "version": "9.2.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fhoek/-/hoek-9.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
       "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
       "license": "BSD-3-Clause"
     },
@@ -382,7 +382,7 @@
     },
     "node_modules/@hapi/iron": {
       "version": "6.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2firon/-/iron-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
       "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -437,7 +437,7 @@
     },
     "node_modules/@hapi/mimos": {
       "version": "5.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fmimos/-/mimos-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
       "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -447,7 +447,7 @@
     },
     "node_modules/@hapi/nigel": {
       "version": "4.0.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fnigel/-/nigel-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
       "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -460,7 +460,7 @@
     },
     "node_modules/@hapi/pez": {
       "version": "5.0.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fpez/-/pez-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
       "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -473,7 +473,7 @@
     },
     "node_modules/@hapi/podium": {
       "version": "4.1.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fpodium/-/podium-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
       "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -484,7 +484,7 @@
     },
     "node_modules/@hapi/shot": {
       "version": "5.0.5",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fshot/-/shot-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
       "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -494,7 +494,7 @@
     },
     "node_modules/@hapi/somever": {
       "version": "3.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fsomever/-/somever-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
       "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -504,7 +504,7 @@
     },
     "node_modules/@hapi/statehood": {
       "version": "7.0.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fstatehood/-/statehood-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
       "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -519,7 +519,7 @@
     },
     "node_modules/@hapi/subtext": {
       "version": "7.0.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fsubtext/-/subtext-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
       "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -534,7 +534,7 @@
     },
     "node_modules/@hapi/teamwork": {
       "version": "5.1.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fteamwork/-/teamwork-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
       "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -543,7 +543,7 @@
     },
     "node_modules/@hapi/topo": {
       "version": "5.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2ftopo/-/topo-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
       "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -552,7 +552,7 @@
     },
     "node_modules/@hapi/validate": {
       "version": "1.1.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fvalidate/-/validate-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
       "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -562,7 +562,7 @@
     },
     "node_modules/@hapi/vise": {
       "version": "4.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fvise/-/vise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
       "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -582,7 +582,7 @@
     },
     "node_modules/@hapi/wreck": {
       "version": "17.1.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fwreck/-/wreck-17.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
       "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2281,7 +2281,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.47.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/mime-db/-/mime-db-1.47.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
       "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
       "license": "MIT",
       "engines": {
@@ -3508,7 +3508,7 @@
     },
     "@hapi/accept": {
       "version": "5.0.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2faccept/-/accept-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
       "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3517,7 +3517,7 @@
     },
     "@hapi/ammo": {
       "version": "5.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fammo/-/ammo-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
       "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
       "requires": {
         "@hapi/hoek": "9.x.x"
@@ -3525,7 +3525,7 @@
     },
     "@hapi/b64": {
       "version": "5.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fb64/-/b64-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
       "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "requires": {
         "@hapi/hoek": "9.x.x"
@@ -3533,7 +3533,7 @@
     },
     "@hapi/boom": {
       "version": "9.1.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fboom/-/boom-9.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
       "integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
       "requires": {
         "@hapi/hoek": "9.x.x"
@@ -3554,7 +3554,7 @@
     },
     "@hapi/bounce": {
       "version": "2.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fbounce/-/bounce-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
       "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3563,12 +3563,12 @@
     },
     "@hapi/bourne": {
       "version": "2.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fbourne/-/bourne-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
       "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
     },
     "@hapi/call": {
       "version": "8.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcall/-/call-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
       "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3577,7 +3577,7 @@
     },
     "@hapi/catbox": {
       "version": "11.1.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcatbox/-/catbox-11.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
       "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3588,7 +3588,7 @@
     },
     "@hapi/catbox-memory": {
       "version": "5.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcatbox-memory/-/catbox-memory-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
       "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3606,7 +3606,7 @@
     },
     "@hapi/content": {
       "version": "5.0.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcontent/-/content-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
       "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
       "requires": {
         "@hapi/boom": "9.x.x"
@@ -3614,7 +3614,7 @@
     },
     "@hapi/cryptiles": {
       "version": "5.1.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fcryptiles/-/cryptiles-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
       "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "requires": {
         "@hapi/boom": "9.x.x"
@@ -3628,12 +3628,12 @@
     },
     "@hapi/file": {
       "version": "2.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2ffile/-/file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
       "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
     },
     "@hapi/hapi": {
       "version": "20.1.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fhapi/-/hapi-20.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.2.tgz",
       "integrity": "sha512-yLppH93as7vw+uaAMVcHEB13eBojuzGhcX948y/CGukNRAlnPV+c1EJGbYPLXVffpH8wCNsI7TrTaeifSFS6Vw==",
       "requires": {
         "@hapi/accept": "^5.0.1",
@@ -3658,7 +3658,7 @@
     },
     "@hapi/heavy": {
       "version": "7.0.1",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fheavy/-/heavy-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
       "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3668,7 +3668,7 @@
     },
     "@hapi/hoek": {
       "version": "9.2.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fhoek/-/hoek-9.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
       "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
     },
     "@hapi/inert": {
@@ -3686,7 +3686,7 @@
     },
     "@hapi/iron": {
       "version": "6.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2firon/-/iron-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
       "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "requires": {
         "@hapi/b64": "5.x.x",
@@ -3728,7 +3728,7 @@
     },
     "@hapi/mimos": {
       "version": "5.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fmimos/-/mimos-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
       "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
       "requires": {
         "@hapi/hoek": "9.x.x",
@@ -3737,7 +3737,7 @@
     },
     "@hapi/nigel": {
       "version": "4.0.2",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fnigel/-/nigel-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
       "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
       "requires": {
         "@hapi/hoek": "^9.0.4",
@@ -3746,7 +3746,7 @@
     },
     "@hapi/pez": {
       "version": "5.0.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fpez/-/pez-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
       "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
       "requires": {
         "@hapi/b64": "5.x.x",
@@ -3758,7 +3758,7 @@
     },
     "@hapi/podium": {
       "version": "4.1.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fpodium/-/podium-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
       "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
       "requires": {
         "@hapi/hoek": "9.x.x",
@@ -3768,7 +3768,7 @@
     },
     "@hapi/shot": {
       "version": "5.0.5",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fshot/-/shot-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
       "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
       "requires": {
         "@hapi/hoek": "9.x.x",
@@ -3777,7 +3777,7 @@
     },
     "@hapi/somever": {
       "version": "3.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fsomever/-/somever-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
       "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
       "requires": {
         "@hapi/bounce": "2.x.x",
@@ -3786,7 +3786,7 @@
     },
     "@hapi/statehood": {
       "version": "7.0.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fstatehood/-/statehood-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
       "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3800,7 +3800,7 @@
     },
     "@hapi/subtext": {
       "version": "7.0.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fsubtext/-/subtext-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
       "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -3814,12 +3814,12 @@
     },
     "@hapi/teamwork": {
       "version": "5.1.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fteamwork/-/teamwork-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
       "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg=="
     },
     "@hapi/topo": {
       "version": "5.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2ftopo/-/topo-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
       "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
@@ -3827,7 +3827,7 @@
     },
     "@hapi/validate": {
       "version": "1.1.3",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fvalidate/-/validate-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
       "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
@@ -3836,7 +3836,7 @@
     },
     "@hapi/vise": {
       "version": "4.0.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fvise/-/vise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
       "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
       "requires": {
         "@hapi/hoek": "9.x.x"
@@ -3855,7 +3855,7 @@
     },
     "@hapi/wreck": {
       "version": "17.1.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/@hapi%2fwreck/-/wreck-17.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
       "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
       "requires": {
         "@hapi/boom": "9.x.x",
@@ -5169,7 +5169,7 @@
     },
     "mime-db": {
       "version": "1.47.0",
-      "resolved": "https://npm-private-registry.prb.rbxd.ds/mime-db/-/mime-db-1.47.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
       "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
     },
     "mimic-response": {


### PR DESCRIPTION
It seems that you used a private NPM registry for some packages. This made `npm i` and `npm ci` fail for me.
Fixed by find & replace.